### PR TITLE
feat. add follow search rule in search fn

### DIFF
--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -1,9 +1,10 @@
 const Post = require("../models/post.model"); // model Post
-
+const User = require("../models/user.model");
 // create and save a new post
 exports.create = async (req, res) => {
   try {
     let dataPost = {
+      user: req.body.user,
       userName: req.body.userName,
       userPhoto: req.body.userPhoto,
       tags: req.body.tags,
@@ -30,22 +31,59 @@ exports.findOne = (req, res) => {};
 // search posts by keyword
 exports.search = async (req, res) => {
   try {
-    let { keyword, sortby, limit = 10, page = 1 } = req.body;
+    let { keyword, sortby, limit = 10, page = 1, userId, authorId } = req.body;
     let filter = keyword ? { content: new RegExp(`${keyword}`) } : {};
-    let sort = sortby === "datetime_pub" ? { createAt: 1 } : {};
+    let sort = sortby === "datetime_pub" ? { createAt: -1 } : {};
     if (page < 0) {
       page = 1;
     }
     let skip = limit * (page - 1);
 
+    if(authorId) { // 查詢特定使用者
+      filter.user = authorId;
+    }
+    else if(userId) { // 動態牆搜尋：1.呈現使用者追蹤對象和自己的發文 2.使用者無追縱對象時，由系統隨機抽樣10人給使用者(不足10人使用全清單)
+      const users = await User.find({ _id: userId });
+      let follow = users[0].follow
+
+      if(!follow.length) { // 處理初始使用者未有follow時的動態牆搜尋 
+        // 之後可用資料庫語法來refact
+        const userList = await User.find({});
+        if(userList.length <= 10) {
+          follow = userList.filter(item => item._id.toString() !== userId).map(item => item._id.toString());
+        }
+        else{
+          let cumulattor = 0;
+          follow = userList
+            .filter(item => {
+              if(item._id.toString() === userId) { return false };
+              if(cumulattor <= 10 && Math.random() > 0.5) {
+                cumulattor++;
+                return true;
+              }
+              else {
+                return false;
+              }
+            })
+            .map(item => item._id.toString());
+        }
+      }
+
+      follow.push(userId);
+
+      filter.user = { $in: follow }
+    }
+
     const count = await Post.find(filter).count();
-    const posts = await Post.find(filter).sort(sort).skip(skip).limit(limit);
+    const posts = await Post.find(filter).sort(sort).skip(skip).limit(limit).populate({
+      path: 'user',
+      select: 'userName avatar'
+    });
     // console.log(posts);
     let resPosts = posts.map((item) => {
       return {
+        user: item.user,
         postId: item._id,
-        userName: item.userName,
-        userPhoto: item.userPhoto,
         content: item.content,
         image: item.image,
         datetime_pub: item.createAt,


### PR DESCRIPTION
1. API POST /search req規格 新增 userId, authorId欄位，userId 協助全體動態牆search查找follow的和自己的文章，authorId 可以針對特定user查找其文章
2. 動態牆搜尋：(1)呈現使用者追蹤對象和自己的發文 (2)使用者無追縱對象時，由系統隨機抽樣10人給使用者(不足10人使用使用者全清單)
3. API POST /search res規格 移除 posts中的userName, userPhoto，改使用user物件(post ref user)回傳