### PR TITLE
feat. add swagger api and modify route, controller for swagger

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,9 @@ var logger = require("morgan");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 
+const swaggerUI = require("swagger-ui-express");
+const swaggerFile = require("./swagger-output.json");
+
 // const { resErrorProd, resErrorDev } = require("./service");
 const {
   uncaughtException,
@@ -44,6 +47,7 @@ app.use("/", indexRouter);
 app.use("/users", usersRouter);
 app.use("/posts", postsRouter);
 app.use("/files",filesRouter)
+app.use("/api-doc", swaggerUI.serve, swaggerUI.setup(swaggerFile));
 
 // catch 404 and forward to error handler
 app.use(error404);

--- a/controllers/file.controller.js
+++ b/controllers/file.controller.js
@@ -6,10 +6,20 @@ const { options } = require('../routes/users');
 
 
 exports.show = async(req,res)=>{
+  /*
+    #swagger.tags = ['Files - 圖片上傳']
+    #swagger.description = '取得圖片 API'
+    #swagger.ignore = true
+  */
   res.send(allImage);
 }
 
 exports.uploadImage = async (req,res)=>{
+  /*
+    #swagger.tags = ['Files - 圖片上傳']
+    #swagger.description = '上傳圖片取得圖片網址 API'
+    #swagger.ignore = true
+  */
     const encode_image = req.file.buffer.toString('base64')
     var imgData = {}
     let options = {

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -4,6 +4,32 @@ const Comment = require("../models/comment.model")
 const { successHandler, errorHandler } =require('../server/handle')
 // create and save a new post
 exports.create = async (req, res) => {
+  /* 
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '新增貼文 API'
+    #swagger.parameters['body'] = {
+      in: 'body',
+      description: '',
+      required: true,
+      schema: {
+        $userId: '62749b880b0c853f222d8696',
+        $tags: '[test]',
+        $type: 'person',
+        $content: '測試發文',
+        image: 'https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ',
+      }
+    }
+    #swagger.responses[200] = {
+      description: '',
+      schema: {
+        status: 'success',
+        message: 'success',
+        data: {
+            postId: '62886e5e526a5458bac3efd6'
+        }
+      }
+    }
+  */
   try {
     const { userId, content, image, likes ,tags} = req.body;
     let dataPost = {
@@ -26,8 +52,15 @@ exports.create = async (req, res) => {
   }
 };
 
+
+// --- 未用到API (後續待刪)--- start
 // retrieve all posts from db
 exports.findAll = async(req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '取得所有貼文 API'
+    #swagger.ignore = true
+  */
   try {
     const allPost = await Post.find().populate({path:'user',select: 'userName avatar'})
     // 將 like 轉為 轉為數字後傳出 
@@ -51,6 +84,11 @@ exports.findAll = async(req, res) => {
 
 // find a single post by id
 exports.findOne = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '取得單一貼文 API'
+    #swagger.ignore = true
+  */
   try {
     const postId = req.params.id
     const postItem = await Post.find({_id:postId})
@@ -66,11 +104,57 @@ exports.findOne = async (req, res) => {
 
 // test post, req body
 exports.testPost = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.ignore = true
+  */
   console.log(req.body);
 };
+// --- 未用到API --- end
 
 // search posts by keyword
 exports.search = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '搜尋貼文 API'
+    #swagger.parameters['body'] = {
+      in: 'body',
+      description: 'keyword: 搜尋關鍵字，空值為全部搜尋,\n sortby: 只提供最新貼文時間排序,\n  limit: 每頁幾筆,\n page: 第幾頁開始,\n userId: 填入登入使用者，會搜尋使用者與使用者追蹤者貼文,\n authorId: 搜尋特定使用者所有發文，此欄如有填，則userId欄位無作用',
+      required: true,
+      schema: {
+        keyword: "", 
+        sortby: "datetime_pub",  
+        limit: 10,
+        page: 1,
+        userId: "62741e710b0c853f222d8691",
+        authorId: "62749ba20b0c853f222d8697"
+      }
+    }
+    #swagger.responses[200] = {
+      description: '',
+      schema: {
+        "status": "success",
+        "payload": {
+          "count": 1,
+          "limit": 10,
+          "page": 1,
+          "posts": [
+            {
+              "user": {
+                  "_id": "62741e710b0c853f222d8691",
+                  "avatar": "https://randomuser.me/api/portraits/lego/3.jpg",
+                  "userName": "DAT"
+              },
+              "postId": "627bd5634b9b3a393e5eb87c",
+              "content": "測試發文",
+              "image": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ",
+              "datetime_pub": "2022-05-11T15:25:23.537Z"
+            }
+          ]
+        }
+      }
+    }
+  */
   try {
     let { keyword, sortby, limit = 10, page = 1, userId, authorId } = req.body;
     let filter = keyword ? { content: new RegExp(`${keyword}`) } : {};
@@ -143,6 +227,39 @@ exports.search = async (req, res) => {
 };
 
 exports.updateComment = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '留言 API'
+    #swagger.parameters['body'] = {
+      in: 'body',
+      description: '',
+      required: true,
+      schema: {
+        $postId: "6288960ac2049c4b43b9e5d3", 
+        $userId: "62749ba20b0c853f222d8697",  
+        $comment: "測試留言",
+      }
+    }
+    #swagger.responses[200] = {
+      description: '被留言之文章原始資料',
+      schema: {
+        "status": "success",
+        "postItem": {
+          "_id": "6288960ac2049c4b43b9e5d3",
+          "user": "62749b880b0c853f222d8696",
+          "tags": [
+            "[test]"
+          ],
+          "type": "person",
+          "image": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ",
+          "content": "測試發文",
+          "likes": [],
+          "createAt": "2022-05-21T07:34:34.522Z",
+          "comments": []
+        }
+      }
+    }
+  */
   try {
     const {postId,userId,comment} = req.body
     const data ={postId,userId,comment}
@@ -162,28 +279,75 @@ exports.updateComment = async (req, res) => {
   }
 };
 
-// update a post by id
-exports.update = async (req, res) => {
-  try {
-    const { userName, content, image, likes } = req.body;
-    const data = { userName, content, image, likes };
-    if (!data.content) {
-      errorHandler(res, '內容不能為空');
-    } else {
-      const editPost = await Post.findByIdAndUpdate(req.params.id, data);
-      console.log(editPost);
-      if (!editPost) {
-        errorHandler(res, '查無此ID，無法更新');
-      } else {
-        successHandler(res, 'success', editPost);
+exports.updateLike = async(req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '按讚/取消讚 API'
+    #swagger.parameters['body'] = {
+      in: 'body',
+      description: '',
+      required: true,
+      schema: {
+        $postId: "6288960ac2049c4b43b9e5d3", 
+        $userId: "62749ba20b0c853f222d8697",  
       }
     }
-  } catch (error) {
-    errorHandler(res, '查無此ID，無法更新');
-  }
-};
-
-exports.updateLike = async(req, res) => {
+    #swagger.responses[200] = {
+      description: '被留言之文章原始資料',
+      schema: {
+        "status": "success",
+        "message": {
+          "user": {
+            "gender": "notAccess",
+            "_id": "62749ba20b0c853f222d8697",
+            "avatar": "https://randomuser.me/api/portraits/lego/3.jpg",
+            "userName": "DDD",
+            "beFollowed": [
+              {
+                "id": "62741e710b0c853f222d8691",
+                "datetime_update": "2022-05-05T19:03:55.552Z"
+              }
+            ],
+            "follow": [
+              {
+                "id": "62741e710b0c853f222d8691",
+                "datetime_update": "2022-05-05T19:03:55.552Z"
+              }
+            ],
+            "likeList": [
+              "627bd5634b9b3a393e5eb87c",
+              "6288960ac2049c4b43b9e5d3"
+            ],
+            "createAt": "2022-05-21T09:49:12.543Z",
+            "updateAt": "2022-05-21T09:49:12.543Z"
+          },
+          "post": {
+            "_id": "6288960ac2049c4b43b9e5d3",
+            "user": "62749b880b0c853f222d8696",
+            "tags": [
+              "[test]"
+            ],
+            "type": "person",
+            "image": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ",
+            "content": "測試發文",
+            "likes": [
+              "62749ba20b0c853f222d8697"
+            ],
+            "createAt": "2022-05-21T07:34:34.522Z",
+            "comments": [
+              {
+                "userName": "DDD",
+                "userPhoto": "https://randomuser.me/api/portraits/lego/3.jpg",
+                "message": "測試留言",
+                "_id": "6288b266ea5a7a1cdc79cd04"
+              }
+            ]
+          }
+        },
+        "data": []
+      }
+    }
+  */
   try {
     const { userId, postId } = req.body
     // 是否存在 post , user id 
@@ -226,11 +390,42 @@ exports.updateLike = async(req, res) => {
   } catch (error) {
       errorHandler(res, error)
   }
-
 }
+
+// --- 未用到API (後續待刪)--- start
+// update a post by id
+exports.update = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '編輯貼文 API'
+    #swagger.ignore = true
+  */
+  try {
+    const { userName, content, image, likes } = req.body;
+    const data = { userName, content, image, likes };
+    if (!data.content) {
+      errorHandler(res, '內容不能為空');
+    } else {
+      const editPost = await Post.findByIdAndUpdate(req.params.id, data);
+      console.log(editPost);
+      if (!editPost) {
+        errorHandler(res, '查無此ID，無法更新');
+      } else {
+        successHandler(res, 'success', editPost);
+      }
+    }
+  } catch (error) {
+    errorHandler(res, '查無此ID，無法更新');
+  }
+};
 
 // delete a post by id
 exports.delete = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '刪除單一貼文 API'
+    #swagger.ignore = true
+  */
   try {
     const postId = req.params.id;
     const deletePost = await Post.findByIdAndDelete(postId);
@@ -246,9 +441,21 @@ exports.delete = async (req, res) => {
 
 // delete all posts
 exports.deleteAll = async (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '刪除所有貼文 API'
+    #swagger.ignore = true
+  */
   await Post.deleteMany({});
   successHandler(res, '全部資料已刪除');
 };
 
 // find all published posts
-exports.findAllPublished = (req, res) => {};
+exports.findAllPublished = (req, res) => {
+  /*
+    #swagger.tags = ['Posts - 貼文']
+    #swagger.description = '取得所有已發表貼文 API'
+    #swagger.ignore = true
+  */
+};
+// --- 未用到API --- end

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -324,7 +324,7 @@ exports.getUserFollowers = (req, res, next) => {
         description: '',
         required: true,
         schema: {
-          $_id: '628897f1c31436e77ba6a8c1',
+          $userId: '628897f1c31436e77ba6a8c1',
         }
       }
       #swagger.responses[200] = {
@@ -342,7 +342,7 @@ exports.getUserFollowers = (req, res, next) => {
       }
     */
     const {body}= req;
-    const id = body._id
+    const id = body.userId
     const followrs = await User.findById(id)
     console.log(followrs)
     successHandle(res,followrs.follow)
@@ -361,8 +361,8 @@ exports.follow = (req, res, next) => {
         description: '',
         required: true,
         schema: {
-          $_id: '628897f1c31436e77ba6a8c1',
-          $userId: '62811968820c4588fef6e57a'
+          $userId: '628897f1c31436e77ba6a8c1',
+          $followId: '62811968820c4588fef6e57a'
         }
       }
       #swagger.responses[200] = {
@@ -374,26 +374,26 @@ exports.follow = (req, res, next) => {
       }
     */
     const {body}= req;
-    const id = body._id //使用者本人
-    const userId = body.userId //欲追蹤的人
+    const id = body.userId //使用者本人
+    const followId = body.followId //欲追蹤的人
     const followrs = await User.findById(id)
     const check = followrs.follow.find(item=>{
-      return item.id === userId;
+      return item.id === followId;
     })
     if(check === undefined){
       await User.findByIdAndUpdate(id,{
-        $push:{ follow:{id:userId} }
+        $push:{ follow:{id:followId} }
       })
-      await User.findByIdAndUpdate(userId,{
+      await User.findByIdAndUpdate(followId,{
         $push:{ beFollowed:{id:id} }
       })
-      const user = await User.findById(userId)
+      const user = await User.findById(followId)
       const beFollowers = user.beFollowed.length
-      successHandle(res,`追蹤成功，user: ${userId} 被追蹤人數 ${beFollowers} 人`)
+      successHandle(res,`追蹤成功，user: ${followId} 被追蹤人數 ${beFollowers} 人`)
     }else{
-      const user = await User.findById(userId)
+      const user = await User.findById(followId)
       const beFollowers = user.beFollowed.length
-      successHandle(res,`已追蹤，user: ${userId} 被追蹤人數 ${beFollowers} 人`)
+      successHandle(res,`已追蹤，user: ${followId} 被追蹤人數 ${beFollowers} 人`)
     }
   })(req, res, next)
 }

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -4,8 +4,15 @@ const User = require('../models/user.model');
 const { successHandle, errorHandle, generateSendJWT } = require('../service');
 const { appError } = require('../exceptions');
 const { filterParams } = require('../helper/utils');
+const { handleErrorAsync } = require('../middleware');
 
+// --- 未用到API (後續待刪)--- start
 exports.getUsers = async (req, res) => {
+  /*
+    #swagger.tags = ['Users - 使用者']
+    #swagger.description = '取得所有使用者 API'
+    #swagger.ignore = true
+  */
   const allUsers = await User.find();
   successHandle(res, allUsers);
 };
@@ -32,6 +39,11 @@ exports.createUser = async (req, res) => {
   }
 };
 exports.resetUserPassword = async (req, res) => {
+  /*
+    #swagger.tags = ['Users - 使用者']
+    #swagger.description = '重設使用者密碼 API'
+    #swagger.ignore = true
+  */
   try {
     const { id } = req.params;
     const { body } = req;
@@ -46,138 +58,321 @@ exports.resetUserPassword = async (req, res) => {
     errorHandle(res, err);
   }
 };
-// user, register
-exports.signUp = async (req, res, next) => {
-  let { email, password, confirmPassword, userName } = req.body;
-  // 內容不可為空
-  if (!email || !password || !confirmPassword || !userName) {
-    return next(appError('400', '欄位未填寫正確！', next));
-  }
-  // 密碼正確
-  if (password !== confirmPassword) {
-    return next(appError('400', '密碼不一致！', next));
-  }
-  // 密碼 8 碼以上，16 碼以下，英大小寫+數+8碼+ exclued 特殊符號
-  let reg = new RegExp(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z]{8,16}$/, 'g');
-  if (password.match(reg) === null) {
-    return next(appError('400', '請確認密碼格式符合格式', next));
-  }
-  // 暱稱 2 個字以上
-  if (!validator.isLength(userName, { min: 2 })) {
-    return next(appError('400', '暱稱字數低於 2 碼', next));
-  }
-  // 是否為 Email
-  if (!validator.isEmail(email)) {
-    return next(appError('400', 'Email 格式不正確', next));
-  }
+// --- 未用到API --- end
 
-  // 加密密碼
-  password = await bcrypt.hash(password, 12);
-  const newUser = await User.create({
-    email,
-    password,
-    userName,
-  });
-  generateSendJWT(newUser, 201, res);
+// user, register
+exports.signUp = (req, res, next) => { 
+  handleErrorAsync(async (req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '註冊使用者 API'
+      #swagger.parameters['body'] = {
+        in: 'body',
+        description: '',
+        required: true,
+        schema: {
+          $userName: 'JOJO',
+          $email: 'test789@gmail.com',
+          $confirmPassword: 'Qwer1234',
+          $password: 'Qwer1234'
+        }
+      }
+      #swagger.responses[200] = {
+        description: '',
+        schema: {
+          "status": "success",
+          "user": {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyODg5YWE5N2Y1MDFlM2Y5NTE4YzYxZSIsImlhdCI6MTY1MzExOTY1NywiZXhwIjoxNjUzNzI0NDU3fQ.T4awTz-A_xEZMromfdFgfTgb5lNU2oLGPGu9cqMCHes",
+            "name": "JOJO"
+          }
+        }
+      }
+    */
+    let { email, password, confirmPassword, userName } = req.body;
+    // 內容不可為空
+    if (!email || !password || !confirmPassword || !userName) {
+      return next(appError('400', '欄位未填寫正確！', next));
+    }
+    // 密碼正確
+    if (password !== confirmPassword) {
+      return next(appError('400', '密碼不一致！', next));
+    }
+    // 密碼 8 碼以上，16 碼以下，英大小寫+數+8碼+ exclued 特殊符號
+    let reg = new RegExp(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z]{8,16}$/, 'g');
+    if (password.match(reg) === null) {
+      return next(appError('400', '請確認密碼格式符合格式', next));
+    }
+    // 暱稱 2 個字以上
+    if (!validator.isLength(userName, { min: 2 })) {
+      return next(appError('400', '暱稱字數低於 2 碼', next));
+    }
+    // 是否為 Email
+    if (!validator.isEmail(email)) {
+      return next(appError('400', 'Email 格式不正確', next));
+    }
+
+    // 加密密碼
+    password = await bcrypt.hash(password, 12);
+    const newUser = await User.create({
+      email,
+      password,
+      userName,
+    });
+    console.log('here')
+    generateSendJWT(newUser, 201, res);
+  })(req, res, next)
 };
 // user, sing in
-exports.signIn = async (req, res, next) => {
-  const { email, password } = req.body;
-  if (!email || !password) {
-    return next(appError(400, '帳號密碼不可為空', next));
-  }
-  const user = await User.findOne({ email }).select('+password');
-  // console.log(password, user.password);
-  const auth = await bcrypt.compare(password, user.password);
-  if (!auth) {
-    return next(appError(400, '您的密碼不正確', next));
-  }
-  generateSendJWT(user, 200, res);
+exports.signIn = (req, res, next) => {
+  handleErrorAsync(async (req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '登入 API'
+      #swagger.parameters['body'] = {
+        in: 'body',
+        description: '',
+        required: true,
+        schema: {
+          $email: 'test789@gmail.com',
+          $password: 'Qwer1234'
+        }
+      }
+      #swagger.responses[200] = {
+        description: '',
+        schema: {
+          "status": "success",
+          "user": {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyODg5YWE5N2Y1MDFlM2Y5NTE4YzYxZSIsImlhdCI6MTY1MzExOTY1NywiZXhwIjoxNjUzNzI0NDU3fQ.T4awTz-A_xEZMromfdFgfTgb5lNU2oLGPGu9cqMCHes",
+            "name": "JOJO"
+          }
+        }
+      }
+    */
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return next(appError(400, '帳號密碼不可為空', next));
+    }
+    const user = await User.findOne({ email }).select('+password');
+    // console.log(password, user.password);
+    const auth = await bcrypt.compare(password, user.password);
+    if (!auth) {
+      return next(appError(400, '您的密碼不正確', next));
+    }
+    generateSendJWT(user, 200, res);
+  })(req, res, next)
 };
 // user, get profile
-exports.getProfile = async (req, res, next) => {
-  try {
-    const userId = req.params.id
-    const userItem = await User.find({_id:userId})
-    if(!Object.keys(userItem).length){
-      errorHandle(res, '查無此ID');
-    }else{
-      successHandle(res,userItem)
-    } 
-  } catch (error) {
-    errorHandle(res, error);
-  }
+exports.getProfile = (req, res, next) => {
+  handleErrorAsync(async (req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '取得單一使用者資料 API'
+      #swagger.security = [{ apiKeyAuth: [] }]
+      #swagger.parameters['id'] = {
+        in: 'path',
+        description: '使用者ID，測試用ID 628897f1c31436e77ba6a8c1',
+        required: true,
+      }
+      #swagger.responses[200] = {
+        description: '',
+        schema: {
+          "status": true,
+          "data": [
+            {
+              "_id": "628897f1c31436e77ba6a8c1",
+              "userName": "JOJO",
+              "avatar": "https://randomuser.me/api/portraits/lego/3.jpg",
+              "gender": "notAccess",
+              "likeList": [],
+              "follow": [],
+              "beFollowed": [],
+              "createAt": "2022-05-21T07:42:41.221Z",
+              "updateAt": "2022-05-21T07:42:41.221Z"
+            }
+          ]
+        }
+      }
+    */
+    try {
+      const userId = req.params.id
+      const userItem = await User.find({_id:userId})
+      if(!Object.keys(userItem).length){
+        errorHandle(res, '查無此ID');
+      }else{
+        successHandle(res,userItem)
+      } 
+    } catch (error) {
+      errorHandle(res, error);
+    }
+  })(req, res, next)
 };
 // user, update password
-exports.updatePassword = async (req, res, next) => {
-  const { password, confirmPassword } = req.body;
-  if (password !== confirmPassword) {
-    return next(appError('400', '密碼不一致！', next));
-  }
-  // 密碼 8 碼以上，16 碼以下，英大小寫+數+8碼+ exclued 特殊符號
-  let reg = new RegExp(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z]{8,16}$/, 'g');
-  if (password.match(reg) === null) {
-    return next(appError('400', '請確認密碼格式符合格式', next));
-  }
+exports.updatePassword = (req, res, next) => {
+  handleErrorAsync(async (req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '重設使用者密碼 API'
+      #swagger.security = [{ apiKeyAuth: [] }]
+      #swagger.parameters['body'] = {
+        in: 'body',
+        description: '',
+        required: true,
+        schema: {
+          $password: 'Qwer1235',
+          $confirmPassword: 'Qwer1235'
+        }
+      }
+      #swagger.responses[200] = {
+        description: '',
+        schema: {
+          "status": "success",
+          "user": {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyODg5N2YxYzMxNDM2ZTc3YmE2YThjMSIsImlhdCI6MTY1MzEyMjEyNCwiZXhwIjoxNjUzNzI2OTI0fQ.Dj3KfnQqdIkIdkdxyijP6C3KmzdQ8cSQPQLPEomPKl0",
+            "name": "JOJO"
+          }
+        }
+      }
+    */
+    const { password, confirmPassword } = req.body;
+    if (password !== confirmPassword) {
+      return next(appError('400', '密碼不一致！', next));
+    }
+    // 密碼 8 碼以上，16 碼以下，英大小寫+數+8碼+ exclued 特殊符號
+    let reg = new RegExp(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z]{8,16}$/, 'g');
+    if (password.match(reg) === null) {
+      return next(appError('400', '請確認密碼格式符合格式', next));
+    }
+  
+    // check new password is same as old password
+    newPassword = await bcrypt.hash(password, 12);
+    const currentUser = await User.findById(req.user.id).select('+password');
+    const equal = await bcrypt.compare(password, currentUser.password);
+    console.log(equal);
+    if (equal) {
+      return next(appError('400', '請輸入新密碼', next));
+    }
+  
+    const user = await User.findByIdAndUpdate(req.user.id, {
+      password: newPassword,
+    });
+    generateSendJWT(user, 200, res);
+  })(req, res, next)
+}
 
-  // check new password is same as old password
-  newPassword = await bcrypt.hash(password, 12);
-  const currentUser = await User.findById(req.user.id).select('+password');
-  const equal = await bcrypt.compare(password, currentUser.password);
-  console.log(equal);
-  if (equal) {
-    return next(appError('400', '請輸入新密碼', next));
-  }
-
-  const user = await User.findByIdAndUpdate(req.user.id, {
-    password: newPassword,
-  });
-  generateSendJWT(user, 200, res);
-};
 // user, update profile
-exports.updateProfile = async (req, res, next) => {
-  const dataTypes = ['string'];
-  const genderTypes = ['female', 'male', 'notAccess'];
-  const data = { userName = null, avatar = null, gender = null } = req.body;
-  const filterObj = filterParams(data);
-
-  // no data
-  if (Object.keys(filterObj).length <= 0) {
-    return next(appError('400', '沒有傳送任何參數資料，無法更新', next));
-  }
-
-  for (const key in filterObj) {
-    // check type
-    if (!dataTypes.includes(typeof filterObj[key])) {
-      return next(appError('400', `${key} 資料格式錯誤，目前為：${typeof filterObj[key]}，請為字串`, next));
+exports.updateProfile = (req, res, next) => {
+  handleErrorAsync(async (req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '編輯個人資料 API'
+      #swagger.security = [{ apiKeyAuth: [] }]
+      #swagger.parameters['body'] = {
+        in: 'body',
+        description: 'gender options: [male, female, notAccess]',
+        required: true,
+        schema: {
+          $userName: 'Jolyne',
+          $avatar: 'https://randomuser.me/api/portraits/lego/3.jpg',
+          $gender: 'female'
+        }
+      }
+      #swagger.responses[200] = {
+        description: '',
+        schema: {
+          "status": true,
+          "data": "success"
+        }
+      }
+    */
+    const dataTypes = ['string'];
+    const genderTypes = ['female', 'male', 'notAccess'];
+    const data = { userName = null, avatar = null, gender = null } = req.body;
+    const filterObj = filterParams(data);
+  
+    // no data
+    if (Object.keys(filterObj).length <= 0) {
+      return next(appError('400', '沒有傳送任何參數資料，無法更新', next));
     }
-
-    // check enum
-    if (key === 'gender' && !genderTypes.includes(filterObj[key])) {
-      return next(appError('400', `性別資料格式錯誤，目前為：${filterObj[key]}，請為：'female', 'male', 'notAccess'`, next))
+  
+    for (const key in filterObj) {
+      // check type
+      if (!dataTypes.includes(typeof filterObj[key])) {
+        return next(appError('400', `${key} 資料格式錯誤，目前為：${typeof filterObj[key]}，請為字串`, next));
+      }
+  
+      // check enum
+      if (key === 'gender' && !genderTypes.includes(filterObj[key])) {
+        return next(appError('400', `性別資料格式錯誤，目前為：${filterObj[key]}，請為：'female', 'male', 'notAccess'`, next))
+      }
     }
-  }
-
-  const newUserInfo = await User.updateOne({_id: req.user.id}, filterObj);
-
-  successHandle(res, 'success', newUserInfo);
-};
+  
+    const newUserInfo = await User.updateOne({_id: req.user.id}, filterObj);
+  
+    successHandle(res, 'success', newUserInfo);
+  })(req, res, next)
+}
 
 //列出使用者所有追蹤的人
-exports.getUserFollowers = async (req, res) => {
-  try{
+exports.getUserFollowers = (req, res, next) => {
+  handleErrorAsync(async (req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '取得使用者自身的所有追蹤 API'
+      #swagger.security = [{ apiKeyAuth: [] }]
+      #swagger.parameters['body'] = {
+        in: 'body',
+        description: '',
+        required: true,
+        schema: {
+          $_id: '628897f1c31436e77ba6a8c1',
+        }
+      }
+      #swagger.responses[200] = {
+        description: '追蹤清單請見id欄位而非_id',
+        schema: {
+          "status": true,
+          "data": [
+            {
+              "id": "62811968820c4588fef6e57a",
+              "_id": "6288ab20d536ebfaec2c5a1b",
+              "datetime_update": "2022-05-21T09:04:32.992Z"
+            }
+          ]
+        }
+      }
+    */
     const {body}= req;
     const id = body._id
     const followrs = await User.findById(id)
+    console.log(followrs)
     successHandle(res,followrs.follow)
-  }catch(err){
-    errorHandle(res,err)
-  }
+  })(req, res, next)
 }
 
 //追蹤功能
-exports.follow = async(req, res) => {
-  try{
+exports.follow = (req, res, next) => {
+  handleErrorAsync(async(req, res, next) => {
+    /*
+      #swagger.tags = ['Users - 使用者']
+      #swagger.description = '追蹤/取消追蹤 API'
+      #swagger.security = [{ apiKeyAuth: [] }]
+      #swagger.parameters['body'] = {
+        in: 'body',
+        description: '',
+        required: true,
+        schema: {
+          $_id: '628897f1c31436e77ba6a8c1',
+          $userId: '62811968820c4588fef6e57a'
+        }
+      }
+      #swagger.responses[200] = {
+        description: '',
+        schema: {
+          "status": true,
+          "data": "追蹤成功，user: 62811968820c4588fef6e57a 被追蹤人數 1 人"
+        }
+      }
+    */
     const {body}= req;
     const id = body._id //使用者本人
     const userId = body.userId //欲追蹤的人
@@ -200,7 +395,5 @@ exports.follow = async(req, res) => {
       const beFollowers = user.beFollowed.length
       successHandle(res,`已追蹤，user: ${userId} 被追蹤人數 ${beFollowers} 人`)
     }
-  }catch(err){
-    errorHandle(res,err)
-  }
+  })(req, res, next)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -419,6 +419,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -528,6 +533,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -1272,6 +1285,27 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "swagger-autogen": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.5.10.tgz",
+      "integrity": "sha512-55QuKeG0ZrUp1S5Vk0pEQer5afhW27jRrmvteRnpxD2cOHOFX30YHmvHaP98VHzKlawy2YIDiKP4RoCAiTsDYg==",
+      "requires": {
+        "figures": "^3.2.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.11.1.tgz",
+      "integrity": "sha512-pf3kfSTYdF9mYFY2VnfJ51wnXlSVhEGdtymhpHzfbFw2jTbiEWgBoVz5EB9aW2EaJvUGTM1YHAXYZX7Jk4RdAQ=="
+    },
+    "swagger-ui-express": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.4.0.tgz",
+      "integrity": "sha512-1CzRkHG386VQMVZK406jcpgnW2a9A5A/NiAjKhsFTQqUBWRF+uGbXTU/mA7WSV3mTzyOQDvjBdWP/c2qd5lqKw==",
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node ./bin/www",
     "start-dev": "NODE_ENV=dev nodemon ./bin/www",
-    "start-prod": "NODE_ENV=production nodemon ./bin/www"
+    "start-prod": "NODE_ENV=production nodemon ./bin/www",
+    "swagger": "node ./swagger.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -23,6 +24,8 @@
     "multer": "^1.4.4",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",
+    "swagger-autogen": "^2.5.10",
+    "swagger-ui-express": "^4.4.0",
     "validator": "^13.7.0"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,9 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
+  /*
+    #swagger.ignore = true
+  */
   res.render('index', { title: 'Express' });
 });
 

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -5,26 +5,26 @@ const postsController = require("../controllers/post.controller");
 // create and save a new post
 router.post("/addPost", postsController.create);
 
-// retrieve all posts from db
-router.get("/getAllPosts", postsController.findAll);
-
-// find a single post by id
-router.get("/getOnePost/:id", postsController.findOne);
-
-// test post, get req body
-router.post("/testPost", postsController.testPost);
-
 // search posts by keyword
 router.post("/search", postsController.search);
 
 // updateComment
 router.post("/updateComment", postsController.updateComment);
 
-// update a post by id
-router.patch("/updatePost/:id", postsController.update);
-
 // update a like by post id and user id 
 router.patch("/updateLike/", postsController.updateLike);
+
+// retrieve all posts from db
+router.get("/getAllPosts", postsController.findAll);
+
+// find a single post by id
+router.get("/getOnePost/:id", postsController.findOne);
+
+// update a post by id
+// router.patch("/updatePost/:id", postsController.update);
+
+// test post, get req body
+router.post("/testPost", postsController.testPost);
 
 // delete a post by id
 router.delete("/deletePost/:id", postsController.delete);

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,17 +3,16 @@ const router = express.Router();
 const usersController = require('../controllers/user.controller');
 const { handleErrorAsync, isAuth } = require('../middleware');
 
-router.post('/sign_up', handleErrorAsync(usersController.signUp)); // 使用者註冊
-router.post('/sign_in', handleErrorAsync(usersController.signIn)); // 使用者登入
-router.get('/profile/:id', isAuth, handleErrorAsync(usersController.getProfile)); // 使用者資料
+router.post('/sign_up', usersController.signUp); // 使用者註冊
+router.post('/sign_in', usersController.signIn); // 使用者登入
+router.get('/profile/:id', isAuth, usersController.getProfile); // 使用者資料
+router.post('/updatePassword', isAuth, usersController.updatePassword); // 修改密碼
+router.patch('/updateProfile', isAuth, usersController.updateProfile);
+router.post('/getFollowrs', isAuth, usersController.getUserFollowers)
+router.post('/follow', isAuth, usersController.follow)
+// router.get('/getAllUsers', usersController.getUsers);
+// router.post('/addUser', usersController.createUser);
+// router.patch('/resetPassword/:id', usersController.resetUserPassword);
 
-router.post('/updatePassword', isAuth, handleErrorAsync(usersController.updatePassword)); // 修改密碼
-
-router.get('/getAllUsers', usersController.getUsers);
-router.post('/addUser', usersController.createUser);
-router.patch('/updateProfile', isAuth, handleErrorAsync(usersController.updateProfile));
-router.patch('/resetPassword/:id', usersController.resetUserPassword);
-router.post('/getFollowrs', usersController.getUserFollowers)
-router.post('/follow',usersController.follow)
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,18 +1,17 @@
 const express = require('express');
 const router = express.Router();
 const usersController = require('../controllers/user.controller');
-const { handleErrorAsync, isAuth } = require('../middleware');
+const { isAuth } = require('../middleware');
 
 router.post('/sign_up', usersController.signUp); // 使用者註冊
 router.post('/sign_in', usersController.signIn); // 使用者登入
 router.get('/profile/:id', isAuth, usersController.getProfile); // 使用者資料
 router.post('/updatePassword', isAuth, usersController.updatePassword); // 修改密碼
 router.patch('/updateProfile', isAuth, usersController.updateProfile);
-router.post('/getFollowrs', isAuth, usersController.getUserFollowers)
+router.post('/getFollowers', isAuth, usersController.getUserFollowers)
 router.post('/follow', isAuth, usersController.follow)
 // router.get('/getAllUsers', usersController.getUsers);
 // router.post('/addUser', usersController.createUser);
 // router.patch('/resetPassword/:id', usersController.resetUserPassword);
-
 
 module.exports = router;

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -1,0 +1,1000 @@
+{
+  "swagger": "2.0",
+  "info": {},
+  "host": "localhost:3005",
+  "basePath": "/",
+  "tags": [],
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "securityDefinitions": {
+    "apiKeyAuth": {
+      "type": "apiKey",
+      "in": "headers",
+      "name": "authorization",
+      "description": "請加入 API Token 需有前綴 Bearer "
+    }
+  },
+  "consumes": [],
+  "produces": [],
+  "paths": {
+    "/users/sign_up": {
+      "post": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "註冊使用者 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string",
+                  "example": "JOJO"
+                },
+                "email": {
+                  "type": "string",
+                  "example": "test789@gmail.com"
+                },
+                "confirmPassword": {
+                  "type": "string",
+                  "example": "Qwer1234"
+                },
+                "password": {
+                  "type": "string",
+                  "example": "Qwer1234"
+                }
+              },
+              "required": [
+                "userName",
+                "email",
+                "confirmPassword",
+                "password"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "user": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyODg5YWE5N2Y1MDFlM2Y5NTE4YzYxZSIsImlhdCI6MTY1MzExOTY1NywiZXhwIjoxNjUzNzI0NDU3fQ.T4awTz-A_xEZMromfdFgfTgb5lNU2oLGPGu9cqMCHes"
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "JOJO"
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/sign_in": {
+      "post": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "登入 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "example": "test789@gmail.com"
+                },
+                "password": {
+                  "type": "string",
+                  "example": "Qwer1234"
+                }
+              },
+              "required": [
+                "email",
+                "password"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "user": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyODg5YWE5N2Y1MDFlM2Y5NTE4YzYxZSIsImlhdCI6MTY1MzExOTY1NywiZXhwIjoxNjUzNzI0NDU3fQ.T4awTz-A_xEZMromfdFgfTgb5lNU2oLGPGu9cqMCHes"
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "JOJO"
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/profile/{id}": {
+      "get": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "取得單一使用者資料 API",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "使用者ID，測試用ID 628897f1c31436e77ba6a8c1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": {
+                        "type": "string",
+                        "example": "628897f1c31436e77ba6a8c1"
+                      },
+                      "userName": {
+                        "type": "string",
+                        "example": "JOJO"
+                      },
+                      "avatar": {
+                        "type": "string",
+                        "example": "https://randomuser.me/api/portraits/lego/3.jpg"
+                      },
+                      "gender": {
+                        "type": "string",
+                        "example": "notAccess"
+                      },
+                      "likeList": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "follow": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "beFollowed": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "createAt": {
+                        "type": "string",
+                        "example": "2022-05-21T07:42:41.221Z"
+                      },
+                      "updateAt": {
+                        "type": "string",
+                        "example": "2022-05-21T07:42:41.221Z"
+                      }
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/users/updatePassword": {
+      "post": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "重設使用者密碼 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "password": {
+                  "type": "string",
+                  "example": "Qwer1235"
+                },
+                "confirmPassword": {
+                  "type": "string",
+                  "example": "Qwer1235"
+                }
+              },
+              "required": [
+                "password",
+                "confirmPassword"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "user": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyODg5N2YxYzMxNDM2ZTc3YmE2YThjMSIsImlhdCI6MTY1MzEyMjEyNCwiZXhwIjoxNjUzNzI2OTI0fQ.Dj3KfnQqdIkIdkdxyijP6C3KmzdQ8cSQPQLPEomPKl0"
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "JOJO"
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/users/updateProfile": {
+      "patch": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "編輯個人資料 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "gender options: [male, female, notAccess]",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string",
+                  "example": "Jolyne"
+                },
+                "avatar": {
+                  "type": "string",
+                  "example": "https://randomuser.me/api/portraits/lego/3.jpg"
+                },
+                "gender": {
+                  "type": "string",
+                  "example": "female"
+                }
+              },
+              "required": [
+                "userName",
+                "avatar",
+                "gender"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "data": {
+                  "type": "string",
+                  "example": "success"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/users/getFollowrs": {
+      "post": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "取得使用者自身的所有追蹤 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "_id": {
+                  "type": "string",
+                  "example": "628897f1c31436e77ba6a8c1"
+                }
+              },
+              "required": [
+                "_id"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "追蹤清單請見id欄位而非_id",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "62811968820c4588fef6e57a"
+                      },
+                      "_id": {
+                        "type": "string",
+                        "example": "6288ab20d536ebfaec2c5a1b"
+                      },
+                      "datetime_update": {
+                        "type": "string",
+                        "example": "2022-05-21T09:04:32.992Z"
+                      }
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/users/follow": {
+      "post": {
+        "tags": [
+          "Users - 使用者"
+        ],
+        "description": "追蹤/取消追蹤 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "_id": {
+                  "type": "string",
+                  "example": "628897f1c31436e77ba6a8c1"
+                },
+                "userId": {
+                  "type": "string",
+                  "example": "62811968820c4588fef6e57a"
+                }
+              },
+              "required": [
+                "_id",
+                "userId"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "data": {
+                  "type": "string",
+                  "example": "追蹤成功，user: 62811968820c4588fef6e57a 被追蹤人數 1 人"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/posts/addPost": {
+      "post": {
+        "tags": [
+          "Posts - 貼文"
+        ],
+        "description": "新增貼文 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userId": {
+                  "type": "string",
+                  "example": "62749b880b0c853f222d8696"
+                },
+                "tags": {
+                  "type": "string",
+                  "example": "[test]"
+                },
+                "type": {
+                  "type": "string",
+                  "example": "person"
+                },
+                "content": {
+                  "type": "string",
+                  "example": "測試發文"
+                },
+                "image": {
+                  "type": "string",
+                  "example": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ"
+                }
+              },
+              "required": [
+                "userId",
+                "tags",
+                "type",
+                "content"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "message": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "postId": {
+                      "type": "string",
+                      "example": "62886e5e526a5458bac3efd6"
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/search": {
+      "post": {
+        "tags": [
+          "Posts - 貼文"
+        ],
+        "description": "搜尋貼文 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "keyword: 搜尋關鍵字，空值為全部搜尋,\n sortby: 只提供最新貼文時間排序,\n limit: 每頁幾筆,\n page: 第幾頁開始,\n userId: 填入登入使用者，會搜尋使用者與使用者追蹤者貼文,\n authorId: 搜尋特定使用者所有發文，此欄如有填，則userId欄位無作用",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "keyword": {
+                  "type": "string",
+                  "example": ""
+                },
+                "sortby": {
+                  "type": "string",
+                  "example": "datetime_pub"
+                },
+                "limit": {
+                  "type": "number",
+                  "example": 10
+                },
+                "page": {
+                  "type": "number",
+                  "example": 1
+                },
+                "userId": {
+                  "type": "string",
+                  "example": "62741e710b0c853f222d8691"
+                },
+                "authorId": {
+                  "type": "string",
+                  "example": "62749ba20b0c853f222d8697"
+                }
+              }
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "limit": {
+                      "type": "number",
+                      "example": 10
+                    },
+                    "page": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "posts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "user": {
+                            "type": "object",
+                            "properties": {
+                              "_id": {
+                                "type": "string",
+                                "example": "62741e710b0c853f222d8691"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "example": "https://randomuser.me/api/portraits/lego/3.jpg"
+                              },
+                              "userName": {
+                                "type": "string",
+                                "example": "DAT"
+                              }
+                            }
+                          },
+                          "postId": {
+                            "type": "string",
+                            "example": "627bd5634b9b3a393e5eb87c"
+                          },
+                          "content": {
+                            "type": "string",
+                            "example": "測試發文"
+                          },
+                          "image": {
+                            "type": "string",
+                            "example": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ"
+                          },
+                          "datetime_pub": {
+                            "type": "string",
+                            "example": "2022-05-11T15:25:23.537Z"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/updateComment": {
+      "post": {
+        "tags": [
+          "Posts - 貼文"
+        ],
+        "description": "留言 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "postId": {
+                  "type": "string",
+                  "example": "6288960ac2049c4b43b9e5d3"
+                },
+                "userId": {
+                  "type": "string",
+                  "example": "62749ba20b0c853f222d8697"
+                },
+                "comment": {
+                  "type": "string",
+                  "example": "測試留言"
+                }
+              },
+              "required": [
+                "postId",
+                "userId",
+                "comment"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "被留言之文章原始資料",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "postItem": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "example": "6288960ac2049c4b43b9e5d3"
+                    },
+                    "user": {
+                      "type": "string",
+                      "example": "62749b880b0c853f222d8696"
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "example": "person"
+                    },
+                    "image": {
+                      "type": "string",
+                      "example": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ"
+                    },
+                    "content": {
+                      "type": "string",
+                      "example": "測試發文"
+                    },
+                    "likes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "createAt": {
+                      "type": "string",
+                      "example": "2022-05-21T07:34:34.522Z"
+                    },
+                    "comments": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/updateLike/": {
+      "patch": {
+        "tags": [
+          "Posts - 貼文"
+        ],
+        "description": "按讚/取消讚 API",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "postId": {
+                  "type": "string",
+                  "example": "6288960ac2049c4b43b9e5d3"
+                },
+                "userId": {
+                  "type": "string",
+                  "example": "62749ba20b0c853f222d8697"
+                }
+              },
+              "required": [
+                "postId",
+                "userId"
+              ]
+            },
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "被留言之文章原始資料",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "success"
+                },
+                "message": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "gender": {
+                          "type": "string",
+                          "example": "notAccess"
+                        },
+                        "_id": {
+                          "type": "string",
+                          "example": "62749ba20b0c853f222d8697"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "example": "https://randomuser.me/api/portraits/lego/3.jpg"
+                        },
+                        "userName": {
+                          "type": "string",
+                          "example": "DDD"
+                        },
+                        "beFollowed": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "example": "62741e710b0c853f222d8691"
+                              },
+                              "datetime_update": {
+                                "type": "string",
+                                "example": "2022-05-05T19:03:55.552Z"
+                              }
+                            }
+                          }
+                        },
+                        "follow": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "example": "62741e710b0c853f222d8691"
+                              },
+                              "datetime_update": {
+                                "type": "string",
+                                "example": "2022-05-05T19:03:55.552Z"
+                              }
+                            }
+                          }
+                        },
+                        "likeList": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "createAt": {
+                          "type": "string",
+                          "example": "2022-05-21T09:49:12.543Z"
+                        },
+                        "updateAt": {
+                          "type": "string",
+                          "example": "2022-05-21T09:49:12.543Z"
+                        }
+                      }
+                    },
+                    "post": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "example": "6288960ac2049c4b43b9e5d3"
+                        },
+                        "user": {
+                          "type": "string",
+                          "example": "62749b880b0c853f222d8696"
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "person"
+                        },
+                        "image": {
+                          "type": "string",
+                          "example": "https://i.picsum.photos/id/817/200/300.jpg?hmac=Egrlh6ZzXMOSu9esbUDMY8PhK3cBCmeqHyWBXm7dnHQ"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "測試發文"
+                        },
+                        "likes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "createAt": {
+                          "type": "string",
+                          "example": "2022-05-21T07:34:34.522Z"
+                        },
+                        "comments": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "userName": {
+                                "type": "string",
+                                "example": "DDD"
+                              },
+                              "userPhoto": {
+                                "type": "string",
+                                "example": "https://randomuser.me/api/portraits/lego/3.jpg"
+                              },
+                              "message": {
+                                "type": "string",
+                                "example": "測試留言"
+                              },
+                              "_id": {
+                                "type": "string",
+                                "example": "6288b266ea5a7a1cdc79cd04"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "items": {}
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {}
+}

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -374,7 +374,7 @@
         ]
       }
     },
-    "/users/getFollowrs": {
+    "/users/getFollowers": {
       "post": {
         "tags": [
           "Users - 使用者"
@@ -389,13 +389,13 @@
             "schema": {
               "type": "object",
               "properties": {
-                "_id": {
+                "userId": {
                   "type": "string",
                   "example": "628897f1c31436e77ba6a8c1"
                 }
               },
               "required": [
-                "_id"
+                "userId"
               ]
             },
             "type": "string"
@@ -460,18 +460,18 @@
             "schema": {
               "type": "object",
               "properties": {
-                "_id": {
+                "userId": {
                   "type": "string",
                   "example": "628897f1c31436e77ba6a8c1"
                 },
-                "userId": {
+                "followId": {
                   "type": "string",
                   "example": "62811968820c4588fef6e57a"
                 }
               },
               "required": [
-                "_id",
-                "userId"
+                "userId",
+                "followId"
               ]
             },
             "type": "string"

--- a/swagger.js
+++ b/swagger.js
@@ -1,0 +1,21 @@
+const swaggerAutogen = require('swagger-autogen')();
+
+const doc = {
+    info: {},
+    host: process.env.NODE_ENV ===  'production' ? 'safe-brushlands-13562.herokuapp.com' : `localhost:3005`,
+    schemes: ['http', 'https'],
+    securityDefinitions: {
+        apiKeyAuth: {
+            type: 'apiKey',
+            in: 'headers',
+            name: 'authorization',
+            description: '請加入 API Token 需有前綴 Bearer '
+        }
+    },
+    definitions: {}
+};
+
+const outputFile = './swagger-output.json';
+const endpointsFiles = ['./app.js'];
+
+swaggerAutogen(outputFile, endpointsFiles, doc);


### PR DESCRIPTION
1. 新增swagger文件
2. 因應swagger-autogen可讀取層數限制，將原users route上的handleErrorAsync，整併到users.controller中並對函數做基礎打包
3. 將目前表列11支範圍之外的API先框列起來，採文件上不顯示，後續討論是否刪除或新增功能API
4. 初步測試有下列API需再確認其功能或回傳資訊整理
(1) /users/follow 追蹤/取消追蹤 api確認取消追蹤是否正常運作
(2) /posts/updateLike 按讚/取消按讚 api 回傳資訊有點過多，請跟前端一同確認是否要縮減必要資訊即可
5. 目前尚未針對錯誤response進行檢測與撰寫文件
6. 修正 /users/getFollowers路由拼字錯誤，/users/getFollowers, /users/follow調整api request命名