### PR TITLE
fix. modify swagger-output.json setting host for heroku

### DIFF
--- a/swagger-output.json
+++ b/swagger-output.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {},
-  "host": "localhost:3005",
+  "host": "safe-brushlands-13562.herokuapp.com",
   "basePath": "/",
   "tags": [],
   "schemes": [


### PR DESCRIPTION
1. 調整swagger-output.json中host設定，直接寫死服務路徑